### PR TITLE
DEPLOY_FILE_MASK to choose which build artifact to dpeloy

### DIFF
--- a/.sti/bin/assemble
+++ b/.sti/bin/assemble
@@ -68,8 +68,12 @@ else
   echo "Copying binaries in source directory into $DEPLOY_DIR for later deployment..."
 fi
 
+if [ -z "$DEPLOY_FILE_MASK" ]; then
+  DEPLOY_FILE_MASK='*'
+fi
+
 if [ -d $OUTPUT_DIR ]; then
-  cp -r $OUTPUT_DIR/* $DEPLOY_DIR >& /dev/null
+  cp -r $OUTPUT_DIR/$DEPLOY_FILE_MASK $DEPLOY_DIR >& /dev/null
 fi
 
 echo "...done"


### PR DESCRIPTION
The build can create more than one file in target directory but only some of them are necessary for deployment. DEPLOY_FILE_MASK env var allow user to choose which artifact he wants to dpeloy.
