### PR TITLE
sed now returns empty string if docker.env.MAIN not set

### DIFF
--- a/.sti/bin/assemble
+++ b/.sti/bin/assemble
@@ -50,7 +50,7 @@ if [ -f "$LOCAL_SOURCE_DIR/pom.xml" ]; then
   mvn --version
   mvn $MAVEN_ARGS -X > .mvn.out
   cat .mvn.out | grep "properties used" > .mvn.props
-  sed 's/.*docker.env.MAIN=\([^, ]*\),.*/\1/' .mvn.props | head -n 1 > $OUTPUT_DIR/JAVA_MAIN_CLASS
+  sed -n 's/.*docker.env.MAIN=\([^, ]*\),.*/\1/p' .mvn.props | head -n 1 > $OUTPUT_DIR/JAVA_MAIN_CLASS
 
   ERR=$?
   if [ $ERR -ne 0 ]; then


### PR DESCRIPTION
When docker.env.MAIN was not set then JAVA_MAIN_CLASS contained the whole line from log file that was parsed. This is now changed - if the property is not set then empty file is created
